### PR TITLE
removed file_ref parameter

### DIFF
--- a/Snippets/profile_photos.py
+++ b/Snippets/profile_photos.py
@@ -12,7 +12,6 @@ with app:
     for i, pic in enumerate(all_pics, 1):
         path = app.download_media(
             message=pic.file_id,
-            file_ref=pic.file_ref,
             file_name=f"profile_pics/{user}/{i}.jpg",
         )
         print(path.split("\\")[-1])


### PR DESCRIPTION
- since pyrogram uses file_id only. decided to remove `file_ref` parameter, uwu~